### PR TITLE
fix: values format of metrics-server extraArgs

### DIFF
--- a/docs/get-started/installation/custom.md
+++ b/docs/get-started/installation/custom.md
@@ -117,9 +117,7 @@ If your Kubernetes cluster uses untrusted certificates, make sure to set `metric
 ```yaml
 apps:
   metrics-server:
-    extraArgs:
-      kubelet-insecure-tls: true
-      kubelet-preferred-address-types: InternalIP
+    extraArgs: ["--kubelet-insecure-tls=true"]
 ```
 
 ### Cluster Autoscaler
@@ -142,9 +140,7 @@ cluster:
 # optionally configure metrics-server for kubelet-insecure-tls
 apps:
   metrics-server:
-    extraArgs:
-      kubelet-insecure-tls: true
-      kubelet-preferred-address-types: InternalIP
+    extraArgs: ["--kubelet-insecure-tls=true"]
 # dns is required!
 dns:
   domainFilters: 

--- a/docs/get-started/installation/custom.md
+++ b/docs/get-started/installation/custom.md
@@ -117,7 +117,8 @@ If your Kubernetes cluster uses untrusted certificates, make sure to set `metric
 ```yaml
 apps:
   metrics-server:
-    extraArgs: ["--kubelet-insecure-tls=true"]
+    extraArgs:
+      - --kubelet-insecure-tls=true
 ```
 
 ### Cluster Autoscaler


### PR DESCRIPTION
The `extraArgs` of the `metrics-server` app expects an array instead of a mapping. This PR fixes the required format accordingly. The argument `--kubelet-preferred-address-types=InternalIP` is already added by default through the platform templates.