### PR TITLE
fix: updated database recovery instructions

### DIFF
--- a/docs/for-ops/disaster-recovery/platform-reinstall.md
+++ b/docs/for-ops/disaster-recovery/platform-reinstall.md
@@ -107,22 +107,11 @@ databases:
       owner: harbor
     externalClusters:
       - name: harbor-backup
-        barmanObjectStore:
-          serverName: harbor-otomi-db
-          destinationPath: s3://<bucket-name>/harbor
-          endpointURL: https://<storage-region>.linodeobjects.com
-          s3Credentials:
-            accessKeyId:
-              name: linode-creds
-              key: S3_STORAGE_ACCOUNT
-            secretAccessKey:
-              name: linode-creds
-              key: S3_STORAGE_KEY
-          wal:
-            compression: gzip
-            maxParallel: 8
-          data:
-            compression: gzip
+        plugin:
+          name: barman-cloud.cloudnative-pg.io
+          parameters:
+            barmanObjectName: harbor-otomi-db
+            serverName: harbor-otomi-db
 ```
 
 In `databases.keycloak`:
@@ -139,22 +128,11 @@ databases:
       owner: keycloak
     externalClusters:
       - name: keycloak-backup
-        barmanObjectStore:
-          serverName: keycloak-db
-          destinationPath: s3://<bucket-name>/keycloak
-          endpointURL: https://<storage-region>.linodeobjects.com
-          s3Credentials:
-            accessKeyId:
-              name: linode-creds
-              key: S3_STORAGE_ACCOUNT
-            secretAccessKey:
-              name: linode-creds
-              key: S3_STORAGE_KEY
-          wal:
-            compression: gzip
-            maxParallel: 8
-          data:
-            compression: gzip
+        plugin:
+          name: barman-cloud.cloudnative-pg.io
+          parameters:
+            barmanObjectName: keycloak-db
+            serverName: keycloak-db
 ```
 
 ## Stopping write operations


### PR DESCRIPTION
With recent changes to CloudnativePG backup and archiving, [as also implemented in Core](https://github.com/linode/apl-core/pull/2299), the instructions for recovery have been updated in this PR.

~~These should be published not before the release of the matching Core changes, since some references to new objects will otherwise not exist in the cluster. However, the previous approach for recovery should still work.~~
Update: The change is released, and these instructions can be published. The previous approach should still work however, as CloudnativePG in its current version supports both.