### PR TITLE
feat: update Redis helm chart docs and network policies lab

### DIFF
--- a/docs/for-devs/console/catalog.md
+++ b/docs/for-devs/console/catalog.md
@@ -32,9 +32,9 @@ The `knative-service` Helm chart can be used to create a Knative `Service` (to d
 
 The `postgresql-cluster` Helm chart can be used to create a cloudnativepg PostgreSQL `Cluster`. Optionally a Prometheus `PodMonitor` and a `Configmap` (for adding a postgresql dashboard to Grafana) can be created.
 
-6. Redis master-replica cluster
+6. Redis high availability cluster
 
-The `redis-cluster` Helm chart can be used to create a Redis master-replica cluster.
+The `redis-ha` Helm chart can be used to create a Redis high availability cluster with master-replica topology and HAProxy load balancer.
 
 7. RabbitMQ Cluster and/or Queues
 

--- a/docs/for-ops/how-to/use-catalog.md
+++ b/docs/for-ops/how-to/use-catalog.md
@@ -40,7 +40,7 @@ The `postgresql-cluster` Helm chart can be used to create a cloudnativepg Postgr
 
 ### quickstart-redis
 
-The `redis-cluster` Helm chart can be used to create a Redis master-replica cluster.
+The `redis-ha` Helm chart can be used to create a Redis high availability cluster with master-replica topology and HAProxy load balancer.
 
 ## Customize the catalog
 

--- a/docs/get-started/labs/create-netpols.md
+++ b/docs/get-started/labs/create-netpols.md
@@ -38,9 +38,9 @@ Outbound Rules let you:
 1. Register a Code Repository with `https://github.com/linode/apl-examples` as the URL.
 2. Create three Docker Container Images. For the Dockerfile path you can use:
 
-   - **vote** → `vote-app/vote/Dockerfile`
-   - **worker** → `vote-app/worker/Dockerfile`
-   - **result** → `vote-app/result/Dockerfile`
+   - **vote** → `./vote-app/vote/Dockerfile`
+   - **worker** → `./vote-app/worker/Dockerfile`
+   - **result** → `./vote-app/result/Dockerfile`
 
 ### 2. Deploy Redis & Postgres
 

--- a/docs/get-started/labs/create-netpols.md
+++ b/docs/get-started/labs/create-netpols.md
@@ -64,7 +64,7 @@ containerPorts:
     protocol: TCP
 env:
   - name: REDIS_HOST
-    value: <redis-ha-name>-redis-ha-haproxy
+    value: <redis-ha-name>-redis-ha
 replicaCount: 1
 ```
 
@@ -91,7 +91,7 @@ env:
         name: <psql-cluster-name>-app
         key: password
   - name: REDIS_HOST
-    value: <redis-ha-name>-redis-ha-haproxy
+    value: <redis-ha-name>-redis-ha
   - name: DATABASE_HOST
     value: <psql-cluster-name>-rw
 replicaCount: 1

--- a/docs/get-started/labs/create-netpols.md
+++ b/docs/get-started/labs/create-netpols.md
@@ -38,9 +38,9 @@ Outbound Rules let you:
 1. Register a Code Repository with `https://github.com/linode/apl-examples` as the URL.
 2. Create three Docker Container Images. For the Dockerfile path you can use:
 
-   - **vote** → `./vote-app/vote/Dockerfile`
-   - **worker** → `./vote-app/worker/Dockerfile`
-   - **result** → `./vote-app/result/Dockerfile`
+   - **vote** → `vote-app/vote/Dockerfile`
+   - **worker** → `vote-app/worker/Dockerfile`
+   - **result** → `vote-app/result/Dockerfile`
 
 ### 2. Deploy Redis & Postgres
 
@@ -64,7 +64,7 @@ containerPorts:
     protocol: TCP
 env:
   - name: REDIS_HOST
-    value: <redis-ha-name>-redis-ha
+    value: <redis-ha-name>
 replicaCount: 1
 ```
 
@@ -91,7 +91,7 @@ env:
         name: <psql-cluster-name>-app
         key: password
   - name: REDIS_HOST
-    value: <redis-ha-name>-redis-ha
+    value: <redis-ha-name>
   - name: DATABASE_HOST
     value: <psql-cluster-name>-rw
 replicaCount: 1

--- a/docs/get-started/labs/create-netpols.md
+++ b/docs/get-started/labs/create-netpols.md
@@ -44,8 +44,8 @@ Outbound Rules let you:
 
 ### 2. Deploy Redis & Postgres
 
-1. In the Catalog, install **redis** (master‑replica) with `auth.enabled=false`.
-2. Install **postgresql** with default settings.
+1. In the Catalog, install **redis** (redis-ha) with default settings.
+2. Install **postgresql** (postgresql-cluster) with default settings.
 
 ### 3. Deploy your workloads
 
@@ -64,7 +64,7 @@ containerPorts:
     protocol: TCP
 env:
   - name: REDIS_HOST
-    value: <redis-cluster-name>-quickstart-redis-master
+    value: <redis-ha-name>-redis-ha-haproxy
 replicaCount: 1
 ```
 
@@ -91,7 +91,7 @@ env:
         name: <psql-cluster-name>-app
         key: password
   - name: REDIS_HOST
-    value: <redis-cluster-name>-quickstart-redis-master
+    value: <redis-ha-name>-redis-ha-haproxy
   - name: DATABASE_HOST
     value: <psql-cluster-name>-rw
 replicaCount: 1
@@ -172,8 +172,12 @@ You’ll allow only Worker & Result to reach Postgres, and only Vote & Worker to
 2. **Name:** `redis-ingress`
 3. **Sources:**
 
-   - Workload: **worker** → `otomi.io/app=worker`
-   - ADD SOURCE → **vote** → `otomi.io/app=vote`
+   - **Workload:** select **worker**
+   - **Label(s):** Select `otomi.io/app=worker`from the drop-down
+   - Click **ADD SOURCE**, then add:
+
+     - **Workload:** vote
+     - **Label(s):** `otomi.io/app=vote`
 
 4. **Target:** Redis → `otomi.io/app=redis`
 5. **Save Changes**

--- a/docs/get-started/labs/use-catalog.md
+++ b/docs/get-started/labs/use-catalog.md
@@ -30,9 +30,9 @@ The `knative-service` Helm chart can be used to create a Knative `Service` (to d
 
 The `postgresql-cluster` Helm chart can be used to create a cloudnativepg PostgreSQL `Cluster`. Optionally a Prometheus `PodMonitor` and a `Configmap` (for adding a postgresql dashboard to Grafana) can be created.
 
-### redis-cluster
+### redis-ha
 
-The `redis-cluster` Helm chart can be used to create a Redis master-replica cluster.
+The `redis-ha` Helm chart can be used to create a Redis high availability cluster with master-replica topology and HAProxy load balancer.
 
 ### rabbitmq-cluster
 


### PR DESCRIPTION
## 📌 Summary

This PR updates Redis helm chart docs and network policies lab according to the `apl-charts` repository’s `redis-ha` chart changes.

Ticket: https://track.akamai.com/jira/browse/APL-1079
PRs: [apl-api](https://github.com/linode/apl-api/pull/801) | [apl-charts](https://github.com/linode/apl-charts/pull/38)

## 🔍 Reviewer Notes

### Testing:
- Create a cluster (select `g6-dedicated-8` to avoid hitting resource limits),
or update the `otomi-api` app _rawValues in your cluster:
```
        image:
            # registry: docker.io
            # repository: linode/apl-api
            pullPolicy: Always
            tag: APL-1079
```
- In `team-admin`, navigate to the Catalog page in the console and add a new `redis-ha` Helm chart using this `Chart.yaml` link: https://github.com/linode/apl-charts/blob/APL-1079/redis-ha/Chart.yaml
- Go back to your desired team (e.g. `team-demo`)
- Follow the [Network Policies lab](https://techdocs.akamai.com/app-platform/docs/create-netpols) with [these changes](https://github.com/linode/apl-docs/pull/130/files#diff-65594dcb02ee67a2b930a15c0ca0232bd9889ced66128e65a0a269b0e134bddf).
- Verify that the new Redis pods and resources are working as expected.