### PR TITLE
feat: remove classic queue example

### DIFF
--- a/docs/get-started/labs/create-rabbitmq-cluster.md
+++ b/docs/get-started/labs/create-rabbitmq-cluster.md
@@ -39,15 +39,6 @@ policies:
     pattern: ".*"
     definition:
       dead-letter-exchange: cc
-      ha-mode: all
-    spec:
-      applyTo: classic_queues
-      priority: 1
-      vhost: "/"
-  - name: my-policy2
-    pattern: ".*"
-    definition:
-      dead-letter-exchange: cc
       max-age: 1h
     spec:
       applyTo: quorum_queues


### PR DESCRIPTION
After updating the rabbitmq chart the example for the classic queue policy is not supported anymore.