### PR TITLE
fix: build petclinic with java 17

### DIFF
--- a/docs/get-started/labs/use-otel.md
+++ b/docs/get-started/labs/use-otel.md
@@ -81,7 +81,7 @@ For this lab we're going to use the [Spring PetClinic Sample Application](https:
 
 6. Optionally you can change the Image name and tag. This is the name and tag used to store the image in the private Harbor image registry.
 
-7. Under `Extra arguments`, click `Add argument`. Set `Name`: `BP_JVM_VERSION` and `Value`: `25`.
+7. Under `Extra arguments`, click `Add argument`. Set `Name`: `BP_JVM_VERSION` and `Value`: `17`.
 
 8. Click `Create Container Image`.
 


### PR DESCRIPTION
this is to address: https://github.com/spring-projects/spring-petclinic/commit/828940e5a1bc51ce1e49410bc1dcf6c4139ea51f
move back from 25 to 17
no need to update techdocs (still at 17)